### PR TITLE
Use large XML/XSL content

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,3 +67,7 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
+# HTTP stuff
+# ~~~~~
+# Raise the default POST limit for large XML/XSL content
+parsers.text.maxLength=4096K


### PR DESCRIPTION
Fixed the NullPointerException when sending large XML or XSL content.
